### PR TITLE
Proper print alignment for Murmer 3 partitioner

### DIFF
--- a/src/main/java/br/com/chaordic/cassandra/ListSubRanges.java
+++ b/src/main/java/br/com/chaordic/cassandra/ListSubRanges.java
@@ -88,7 +88,9 @@ public class ListSubRanges {
             throws InvalidRequestException, TException {
         List<CfSplit> cfSplits = client.describe_splits_ex(columnFamily, startToken, endToken, keysPerSplit);
         for (CfSplit cfSplit : cfSplits) {
-            System.out.printf("%s %s %d\n", cfSplit.start_token, cfSplit.end_token, cfSplit.row_count);
+            String st = String.format("%1$-39s", cfSplit.start_token);
+            String et = String.format("%1$-39s", cfSplit.end_token);
+            System.out.printf("%s %s %d\n", st, et, cfSplit.row_count);
         }
     }
 


### PR DESCRIPTION
Thanks for this utility. I'm giving a talk in the near future and subrange repair is a key point I want to make. This is what I was looking for to give people that aren't on Datastax Enterprise.

I made a minor update to align the output properly when the Murmur3 partitioner is used.
